### PR TITLE
rename schema arg to schema_override

### DIFF
--- a/python/run_and_monitor_dbt_cloud_job.py
+++ b/python/run_and_monitor_dbt_cloud_job.py
@@ -43,7 +43,7 @@ run_status_map = { # dbt run statuses are encoded as integers. This map provides
 }
 #------------------------------------------------------------------------------
 
-def run_job(url, headers, cause, branch=None, schema=None ) -> int:
+def run_job(url, headers, cause, branch=None, schema_override=None ) -> int:
   """
   Runs a dbt job
   """


### PR DESCRIPTION
We are using this for our dbt CI/CD checks (Jenkins + GH Enterprise) and while doing some debugging I found that `run_job` was checking `schema_override` but not accepting that as an arg. I propose renaming `schema` in this PR.

### This PR includes:
- rename `schema` in `run_job()` to `schema_override`

### This PR resolves the following issues:
- `schema_override` being unintentionally referenced from the global scope